### PR TITLE
Add firstname + lastname to Users model and a link to edit the profile

### DIFF
--- a/app/assets/stylesheets/components/_signin.scss
+++ b/app/assets/stylesheets/components/_signin.scss
@@ -12,7 +12,7 @@
 
   .form-new {
     background-color: white;
-    top: 150px;
+    top: 20px;
     border-radius: 4px;
   }
 

--- a/app/assets/stylesheets/components/_signin.scss
+++ b/app/assets/stylesheets/components/_signin.scss
@@ -22,4 +22,13 @@
     border-color: #5C415D;
     border-radius: 4px;
   }
+
+  .my-hint {
+   white-space: nowrap !important;
+  }
+
+  .unhappy {
+    margin-left: 10px;
+    margin-bottom: 0px;
+  }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   include Pundit
 
   # Pundit: white-list approach.
@@ -19,5 +22,13 @@ class ApplicationController < ActionController::Base
 
   def skip_pundit?
     devise_controller? || params[:controller] =~ /(^(rails_)?admin)|(^pages$)/
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:first_name, :photo, :last_name, :email, :password) }
+
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:first_name, :photo, :last_name, :email, :password, :current_password) }
   end
 end

--- a/app/views/components/_dashboard_menu.html.erb
+++ b/app/views/components/_dashboard_menu.html.erb
@@ -10,10 +10,5 @@
         <p>My Bars</p>
       </div>
     <% end %>
-    <%= link_to("#") do%>
-      <div class="dashboard-menu-item">
-        <p>My Profile</p>
-      </div>
-    <% end %>
   </div>
 </div>

--- a/app/views/components/_navbar.html.erb
+++ b/app/views/components/_navbar.html.erb
@@ -33,10 +33,11 @@
           <li>
           <div class="dropdown">
             <a class="dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <%= render "components/avatar", name: current_user.email %>
+              <%= render "components/avatar", name: current_user.first_name %>
             </a>
 
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+              <%= link_to 'Edit Profile', edit_user_registration_path, class: 'dropdown-item' %>
               <%= link_to 'Create a bar', new_bar_path, class: 'dropdown-item' %>
               <div class="dropdown-divider"></div>
               <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'dropdown-item' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -32,12 +32,12 @@
 
                         required: true,
                         input_html: { autocomplete: "current-password" } %>
-            <div class="d-flex">
+            <div class="d-flex align-items-center">
               <%= f.label :photo, "Photo :", class:"pr-3" %>
               <%= f.input :photo, as: :file, class:"mt-2", label: false %>
             </div>
           </div>
-          <div class="form-actions">
+          <div class="form-actions ml-0">
             <%= f.button :submit, "Update" %>
             <div class="form-link d-flex justify-content-between">
               <p class="unhappy">Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,35 +1,50 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
-
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
-
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
-    <% end %>
-
-    <%= f.input :password,
-                hint: "leave it blank if you don't want to change it",
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :current_password,
-                hint: "we need your current password to confirm your changes",
-                required: true,
-                input_html: { autocomplete: "current-password" } %>
+<div class="form-component-signin">
+  <div class="main-container-signin">
+    <div class="col-4 offset-4 form-new p-4 shadow ">
+      <div class="title-form text-center my-3">
+        <h2>Edit Profile</h2>
+      </div>
+      <div class="title-form">
+        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <%= f.error_notification %>
+          <div class="form-inputs">
+            <div class="d-flex justify-content-between">
+              <div style='width: 200px;'><%= f.input :first_name, required: true, autofocus: true %></div>
+              <div style='width: 200px;'><%= f.input :last_name, required: true, autofocus: true %></div>
+            </div>
+            <%= f.input :email, required: true, autofocus: true %>
+            <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+              <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+            <% end %>
+            <div class="d-flex justify-content-between">
+              <div style='width: 200px;'><%= f.input :password,
+                        hint: "leave it blank if you don't want to change it",
+                        required: false,
+                        input_html: { autocomplete: "new-password" } %>
+              </div>
+              <div style='width: 200px;'><%= f.input :password_confirmation,
+                        required: false,
+                        input_html: { autocomplete: "new-password" } %>
+              </div>
+            </div>
+            <%= f.input :current_password,
+                        hint: "we need your current password to confirm your changes",
+                        required: true,
+                        input_html: { autocomplete: "current-password" } %>
+            <div class="d-flex">
+              <%= f.label :photo, "Photo :", class:"pr-3" %>
+              <%= f.input :photo, as: :file, class:"btn-primary", label: false %>
+            </div>
+          </div>
+          <div class="form-actions">
+            <%= f.button :submit, "Update" %>
+          </div>
+        <% end %>
+        <div class="form-link d-flex justify-content-between">
+          <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+          <%= link_to "Back", :back %>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,7 +18,7 @@
             <% end %>
             <div class="d-flex justify-content-between">
               <div style='width: 200px;'><%= f.input :password,
-                        hint: "leave it blank if you don't want to change it",
+                        hint: "Leave it blank if you don't want to change it.",
                         required: false,
                         input_html: { autocomplete: "new-password" } %>
               </div>
@@ -28,22 +28,23 @@
               </div>
             </div>
             <%= f.input :current_password,
-                        hint: "we need your current password to confirm your changes",
+                        hint: "We need your current password to confirm your changes",
+
                         required: true,
                         input_html: { autocomplete: "current-password" } %>
             <div class="d-flex">
               <%= f.label :photo, "Photo :", class:"pr-3" %>
-              <%= f.input :photo, as: :file, class:"btn-primary", label: false %>
+              <%= f.input :photo, as: :file, class:"mt-2", label: false %>
             </div>
           </div>
           <div class="form-actions">
             <%= f.button :submit, "Update" %>
+            <div class="form-link d-flex justify-content-between">
+              <p class="unhappy">Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+              <%= link_to "Back", :back %>
+            </div>
           </div>
         <% end %>
-        <div class="form-link d-flex justify-content-between">
-          <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-          <%= link_to "Back", :back %>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,3 @@
-
-
 <div class="form-component-signin">
   <div class="main-container-signin">
     <div class="col-4 offset-4 form-new my-4 p-4 shadow ">
@@ -10,6 +8,10 @@
         <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
           <%= f.error_notification %>
           <div class="form-inputs">
+            <div class="d-flex justify-content-between">
+              <div style='width: 200px;'><%= f.input :first_name, required: true, autofocus: true %></div>
+              <div style='width: 200px;'><%= f.input :last_name, required: true, autofocus: true %></div>
+            </div>
             <%= f.input :email,
                         required: true,
                         autofocus: true,
@@ -21,14 +23,18 @@
             <%= f.input :password_confirmation,
                         required: true,
                         input_html: { autocomplete: "new-password" } %>
+            <div class="d-flex">
+              <%= f.label :photo, "Photo :", class:"pr-3" %>
+              <%= f.input :photo, as: :file, class:"btn-primary", label: false %>
+            </div>
           </div>
 
-          <div class="form-actions">
+          <div class="form-actions d-flex justify-content-between">
             <%= f.button :submit, "Sign up" %>
+            <%= render 'components/button_link', text: "Log In", link: "devise/shared/links" %>
           </div>
         <% end %>
       </div>
-    <%= render "devise/shared/links" %>
     </div>
   </div>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -232,7 +232,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -60,7 +60,7 @@ SimpleForm.setup do |config|
     b.use :label
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # vertical input for boolean
@@ -71,7 +71,7 @@ SimpleForm.setup do |config|
       bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
       bb.use :label, class: 'form-check-label'
       bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -84,7 +84,7 @@ SimpleForm.setup do |config|
     end
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # vertical input for inline radio buttons and check boxes
@@ -96,7 +96,7 @@ SimpleForm.setup do |config|
     end
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # vertical file input
@@ -109,7 +109,7 @@ SimpleForm.setup do |config|
     b.use :label
     b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # vertical multi select
@@ -121,7 +121,7 @@ SimpleForm.setup do |config|
       ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # vertical range input
@@ -133,7 +133,7 @@ SimpleForm.setup do |config|
     b.use :label
     b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
 
@@ -152,7 +152,7 @@ SimpleForm.setup do |config|
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -168,7 +168,7 @@ SimpleForm.setup do |config|
         bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
         bb.use :label, class: 'form-check-label'
         bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-        bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+        bb.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
       end
     end
   end
@@ -181,7 +181,7 @@ SimpleForm.setup do |config|
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -193,7 +193,7 @@ SimpleForm.setup do |config|
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -208,7 +208,7 @@ SimpleForm.setup do |config|
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
       ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -222,7 +222,7 @@ SimpleForm.setup do |config|
         bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
       end
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -236,7 +236,7 @@ SimpleForm.setup do |config|
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
       ba.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -256,7 +256,7 @@ SimpleForm.setup do |config|
 
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # inline input for boolean
@@ -266,7 +266,7 @@ SimpleForm.setup do |config|
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label, class: 'form-check-label'
     b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
 
@@ -280,7 +280,7 @@ SimpleForm.setup do |config|
       bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
       bb.use :label, class: 'custom-control-label'
       bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -292,7 +292,7 @@ SimpleForm.setup do |config|
       bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
       bb.use :label, class: 'custom-control-label'
       bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
     end
   end
 
@@ -305,7 +305,7 @@ SimpleForm.setup do |config|
     end
     b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # custom input for inline radio buttons and check boxes
@@ -317,7 +317,7 @@ SimpleForm.setup do |config|
     end
     b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # custom file input
@@ -333,7 +333,7 @@ SimpleForm.setup do |config|
       ba.use :label, class: 'custom-file-label'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
     end
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # custom multi select
@@ -345,7 +345,7 @@ SimpleForm.setup do |config|
       ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # custom range input
@@ -357,7 +357,7 @@ SimpleForm.setup do |config|
     b.use :label
     b.use :input, class: 'custom-range', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
 
@@ -378,7 +378,7 @@ SimpleForm.setup do |config|
   #     ba.optional :append
   #   end
   #   b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-  #   b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  #   b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   # end
 
 
@@ -396,7 +396,7 @@ SimpleForm.setup do |config|
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
   # custom multi select
@@ -406,7 +406,7 @@ SimpleForm.setup do |config|
     b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'my-hint form-text text-muted' }
   end
 
 

--- a/db/migrate/20200220092948_add_first_name_and_last_name_to_users.rb
+++ b/db/migrate/20200220092948_add_first_name_and_last_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddFirstNameAndLastNameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_19_115328) do
+ActiveRecord::Schema.define(version: 2020_02_20_092948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,8 @@ ActiveRecord::Schema.define(version: 2020_02_19_115328) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Is done :
- Added columns in the user schema DB (first_name and last_name)
- Added in the sign-up form the first_name, last_name and photo inputs
- Changed the display of the first name beside the avatar instead of the email
- added a link to edit the profile in the dropdown menu
- set the edit form to be in one page
- set the sign up form to be in one page

![Capture d’écran 2020-02-20 à 12 28 50](https://user-images.githubusercontent.com/56273264/74929834-996a1c00-53dc-11ea-953a-6c07e391b643.png)